### PR TITLE
Added RV3028 support for Timers and PeriodicUpdate Interrupts

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -47,6 +47,16 @@ getUNIX	KEYWORD2
 enableAlarmInterrupt	KEYWORD2
 disableAlarmInterrupt	KEYWORD2
 readAlarmInterruptFlag	KEYWORD2
+clearAlarmInterruptFlag	KEYWORD2
+
+disableTimer	KEYWORD2
+disableTimerInterrupt	KEYWORD2
+readTimerInterruptFlag	KEYWORD2
+clearTimerInterruptFlag	KEYWORD2
+
+disablePeriodicUpdateInterrupt	KEYWORD2
+readPeriodicUpdateInterruptFlag	KEYWORD2
+clearPeriodicUpdateInterruptFlag	KEYWORD2
 
 enableTrickleCharge	KEYWORD2
 disableTrickleCharge	KEYWORD2

--- a/src/RV-3028-C7.cpp
+++ b/src/RV-3028-C7.cpp
@@ -69,7 +69,7 @@ RV3028::RV3028(void)
 
 }
 
-boolean RV3028::begin(TwoWire &wirePort)
+bool RV3028::begin(TwoWire &wirePort)
 {
 	//We require caller to begin their I2C port, with the speed of their choice
 	//external to the library
@@ -171,7 +171,7 @@ bool RV3028::setToCompilerTime()
 	{
 		uint8_t hour = BUILD_HOUR;
 
-		boolean pm = false;
+		bool pm = false;
 
 		if (hour == 0)
 			hour += 12;
@@ -334,7 +334,7 @@ void RV3028::set12Hour()
 		writeRegister(RV3028_CTRL2, setting);
 
 		//Take the current hours and convert to 12, complete with AM/PM bit
-		boolean pm = false;
+		bool pm = false;
 
 		if (hour == 0)
 			hour += 12;
@@ -363,7 +363,7 @@ void RV3028::set24Hour()
 	{
 		//Not sure what changing the CTRL2 register will do to hour register so let's get a copy
 		uint8_t hour = readRegister(RV3028_HOURS); //Get the current 12 hour formatted time in BCD
-		boolean pm = false;
+		bool pm = false;
 		if (hour & (1 << HOURS_AM_PM)) //Is the AM/PM bit set?
 		{
 			pm = true;
@@ -423,17 +423,17 @@ If you want to set a weekday alarm (setWeekdayAlarm_not_Date = true), set 'date_
 void RV3028::enableAlarmInterrupt(uint8_t min, uint8_t hour, uint8_t date_or_weekday, bool setWeekdayAlarm_not_Date, uint8_t mode)
 {
 	//disable Alarm Interrupt to prevent accidental interrupts during configuration
-	disableAlarmInterrupt(); clearInterrupts();
+	disableAlarmInterrupt(); 
+	clearAlarmInterruptFlag();
 
 	//ENHANCEMENT: Add Alarm in 12 hour mode
 	set24Hour();
+
 	//Set WADA bit (Weekday/Date Alarm)
-	uint8_t value = readRegister(RV3028_CTRL1);
 	if (setWeekdayAlarm_not_Date)
-		value &= ~(1 << CTRL1_WADA);
+		clearBit (RV3028_CTRL1, CTRL1_WADA);
 	else
-		value |= 1 << CTRL1_WADA;
-	writeRegister(RV3028_CTRL1, value);
+		setBit (RV3028_CTRL1, CTRL1_WADA);
 
 	//Write alarm settings in registers 0x07 to 0x09
 	uint8_t alarmTime[3];
@@ -457,23 +457,145 @@ void RV3028::enableAlarmInterrupt(uint8_t min, uint8_t hour, uint8_t date_or_wee
 
 void RV3028::enableAlarmInterrupt()
 {
-	uint8_t value = readRegister(RV3028_CTRL2);
-	value |= (1 << CTRL2_AIE); //Set the interrupt enable bit
-	writeRegister(RV3028_CTRL2, value);
+	setBit(RV3028_CTRL2, CTRL2_AIE);
 }
 
 //Only disables the interrupt (not the alarm flag)
 void RV3028::disableAlarmInterrupt()
 {
-	uint8_t value = readRegister(RV3028_CTRL2);
-	value &= ~(1 << CTRL2_AIE); //Clear the interrupt enable bit
-	writeRegister(RV3028_CTRL2, value);
+	clearBit(RV3028_CTRL2, CTRL2_AIE);
 }
 
 bool RV3028::readAlarmInterruptFlag()
 {
-	uint8_t stat = status();
-	return (stat & (1 << STATUS_AF));
+	return readBit(RV3028_STATUS, STATUS_AF);
+}
+
+void RV3028::clearAlarmInterruptFlag()
+{
+	clearBit(RV3028_STATUS, STATUS_AF);
+}
+
+void RV3028::setTimer(bool timer_repeat, uint16_t timer_frequency, uint16_t timer_value, bool set_interrupt, bool start_timer)
+{
+	disableTimer();
+	disableTimerInterrupt(); 
+	clearTimerInterruptFlag();
+
+	writeRegister(RV3028_TIMERVAL_0,  timer_value & 0xff);
+	writeRegister(RV3028_TIMERVAL_1,  timer_value >> 8);
+	
+	uint8_t ctrl1_val = readRegister(RV3028_CTRL1);
+	if (timer_repeat)
+	{
+		ctrl1_val |= 1 << CTRL1_TRPT;
+	}
+	else
+	{
+		ctrl1_val &= ~(1 << CTRL1_TRPT);
+	}
+ 	switch (timer_frequency)
+	{
+		case 4096:		// 4096Hz (default)		// up to 122us error on first time
+			ctrl1_val &= ~3; // Clear both the bits
+		break;
+		
+		case 64:		// 64Hz					// up to 7.813ms error on first time
+			ctrl1_val &= ~3; // Clear both the bits
+			ctrl1_val |= 1;	
+		break;
+		
+		case 1:			// 1Hz					// up to 7.813ms error on first time
+			ctrl1_val &= ~3; // Clear both the bits
+			ctrl1_val |= 2;
+		break;
+		
+		case 60000:		// 60 seconds			// up to 7.813ms error on first time
+			ctrl1_val |= 3; // Set both bits
+		break;
+		
+	}
+	
+	if (set_interrupt)
+	{
+		enableTimerInterrupt();
+	}
+	if (start_timer)
+	{
+		ctrl1_val |= (1 << CTRL1_TE);
+	}
+	writeRegister(RV3028_CTRL1, ctrl1_val);
+}
+
+
+void RV3028::enableTimerInterrupt()
+{
+	setBit(RV3028_CTRL2, CTRL2_TIE);
+}
+
+void RV3028::disableTimerInterrupt()
+{
+	clearBit(RV3028_CTRL2, CTRL2_TIE);
+}
+
+bool RV3028::readTimerInterruptFlag()
+{
+	return readBit(RV3028_STATUS, STATUS_TF);
+}
+
+void RV3028::clearTimerInterruptFlag()
+{
+	clearBit(RV3028_STATUS, STATUS_TF);
+}
+
+void RV3028::enableTimer()
+{
+	setBit(RV3028_CTRL1, CTRL1_TE);
+}
+
+void RV3028::disableTimer()
+{
+	clearBit(RV3028_CTRL1, CTRL1_TE);
+}
+
+void RV3028::setPeriodicUpdate(bool every_second, bool enable_interrupt, bool enable_clock_output)
+{
+	disablePeriodicUpdateInterrupt();
+	clearPeriodicUpdateInterruptFlag();
+	
+	if (every_second)
+	{
+		clearBit(RV3028_CTRL1, CTRL1_USEL);
+	}
+	else
+	{	// every minute
+		setBit(RV3028_CTRL1, CTRL1_USEL);
+	}
+	
+	if (enable_interrupt)
+	{
+		setBit(RV3028_CTRL2, CTRL2_UIE);
+	}
+	
+	if (enable_clock_output)
+	{
+		setBit(RV3028_INT_MASK, IMT_MASK_CUIE);
+	}
+}
+
+void RV3028::disablePeriodicUpdateInterrupt()
+{
+	clearBit (RV3028_CTRL2, CTRL2_UIE);		
+}
+
+bool RV3028::readPeriodicUpdateInterruptFlag()
+{
+	return readBit(RV3028_STATUS, STATUS_UF);
+}
+
+void RV3028::clearPeriodicUpdateInterruptFlag()
+{
+	clearBit (RV3028_STATUS, STATUS_UF);
 }
 
 /*********************************
@@ -542,7 +664,7 @@ uint8_t RV3028::status(void)
 
 void RV3028::clearInterrupts() //Read the status register to clear the current interrupt flags
 {
-	status();
+	writeRegister(RV3028_STATUS, 0);
 }
 
 uint8_t RV3028::BCDtoDEC(uint8_t val)
@@ -564,13 +686,8 @@ uint8_t RV3028::readRegister(uint8_t addr)
 
 	_i2cPort->requestFrom(RV3028_ADDR, (uint8_t)1);
 	if (_i2cPort->available()) {
-		uint8_t zws = _i2cPort->read();
-
-		//clear status register when it was read
-		if (addr == RV3028_STATUS) writeRegister(addr, 0);
-
-		return zws;
-	}
+		return _i2cPort->read();
+		}
 	else {
 		return (0xFF); //Error
 	}
@@ -673,3 +790,32 @@ bool RV3028::waitforEEPROM()
 
 	return millis() < timeout;
 }
+
+void RV3028::reset()
+{
+	setBit(RV3028_CTRL2, CTRL2_RESET);
+}
+
+
+void RV3028::setBit(uint8_t reg_addr, uint8_t bit_num)
+{
+	uint8_t value = readRegister(reg_addr);
+	value |= (1 << bit_num); //Set the bit
+	writeRegister(reg_addr, value);
+}
+
+void RV3028::clearBit(uint8_t reg_addr, uint8_t bit_num)
+{
+	uint8_t value = readRegister(reg_addr);
+	value &= ~(1 << bit_num); //Clear the bit
+	writeRegister(reg_addr, value);
+}
+
+bool RV3028::readBit(uint8_t reg_addr, uint8_t bit_num)
+{
+	uint8_t value = readRegister(reg_addr);
+	value &= (1 << bit_num); 
+	return value;
+	
+}
+

--- a/src/RV-3028-C7.h
+++ b/src/RV-3028-C7.h
@@ -98,6 +98,7 @@ Distributed as-is; no warranty is given.
 
 //EEPROM Registers
 #define EEPROM_Clkout_Register			0x35
+#define RV3028_EEOffset_8_1				0x36	//bits 8 to 1 of EEOffset. Bit 0 is bit 7 of register 0x37 
 #define EEPROM_Backup_Register			0x37
 
 
@@ -160,6 +161,10 @@ Distributed as-is; no warranty is given.
 #define	TCR_6K							0b10			//Trickle Charge Resistor 6kOhm
 #define	TCR_11K							0b11			//Trickle Charge Resistor 11kOhm
 
+#define IMT_MASK_CEIE					3				//Clock output when Event Interrupt bit. 
+#define IMT_MASK_CAIE					2				//Clock output when Alarm Interrupt bit.
+#define IMT_MASK_CTIE					1				//Clock output when Periodic Countdown Timer Interrupt bit.
+#define IMT_MASK_CUIE					0				//Clock output when Periodic Time Update Interrupt bit.
 
 #define TIME_ARRAY_LENGTH 7 // Total number of writable values in device
 
@@ -179,7 +184,7 @@ public:
 
 	RV3028(void);
 
-	boolean begin(TwoWire &wirePort = Wire);
+	bool begin(TwoWire &wirePort = Wire);
 
 	bool setTime(uint8_t sec, uint8_t min, uint8_t hour, uint8_t weekday, uint8_t date, uint8_t month, uint16_t year);
 	bool setTime(uint8_t * time, uint8_t len);
@@ -220,7 +225,21 @@ public:
 	void enableAlarmInterrupt();
 	void disableAlarmInterrupt();
 	bool readAlarmInterruptFlag();
+	void clearAlarmInterruptFlag();
 
+	void setTimer(bool timer_repeat, uint16_t timer_frequency, uint16_t timer_value, bool setInterrupt, bool Go);
+	void enableTimer();
+	void disableTimer();
+	void enableTimerInterrupt();
+	void disableTimerInterrupt();
+	bool readTimerInterruptFlag();
+	void clearTimerInterruptFlag();
+
+	void setPeriodicUpdate(bool every_second, bool enable_interrupt, bool enable_clock_output);
+	void disablePeriodicUpdateInterrupt();
+	bool readPeriodicUpdateInterruptFlag();
+	void clearPeriodicUpdateInterruptFlag();
+	
 	void enableTrickleCharge(uint8_t tcr = TCR_11K); //Trickle Charge Resistor default 11k
 	void disableTrickleCharge();
 	bool setBackupSwitchoverMode(uint8_t val);
@@ -241,14 +260,16 @@ public:
 	bool writeConfigEEPROM_RAMmirror(uint8_t eepromaddr, uint8_t val);
 	uint8_t readConfigEEPROM_RAMmirror(uint8_t eepromaddr);
 	bool waitforEEPROM();
+	void reset();
 
+	void setBit(uint8_t reg_addr, uint8_t bit_num);
+	void clearBit(uint8_t reg_addr, uint8_t bit_num);
+	bool readBit(uint8_t reg_addr, uint8_t bit_num);
 private:	
 	uint8_t _time[TIME_ARRAY_LENGTH];
 	TwoWire *_i2cPort;
 };
 
 //POSSIBLE ENHANCEMENTS :
-//ENHANCEMENT: Countdown Timer / Countdown Interrupt
-//ENHANCEMENT: Periodic Time Update Interrupt
 //ENHANCEMENT: Battery Interrupt / check battery voltage
 //ENHANCEMENT: Clock Output


### PR DESCRIPTION
Removed automatic clearing of RV3028_STATUS register in readRegister()

RV3028::setTimer(bool timer_repeat, uint16_t timer_frequency, uint16_t timer_value, bool set_interrupt, bool start_timer);
RV3028::setPeriodicUpdate(bool every_second, bool enable_interrupt, bool enable_clock_output);