### PR TITLE
Update Trickle Charge Resistor Values

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,13 +133,13 @@ _every_second_ specifies the interrupt to occur either every second or every min
 <hr>
 
 ### Trickle Charge functions
-###### `enableTrickleCharge(uint8_t tcr = TCR_11K)`
+###### `enableTrickleCharge(uint8_t tcr = TCR_15K)`
 ###### `disableTrickleCharge()`
 At "enableTrickleCharge" you can choose the series resistor:  
-TCR_1K for 1kOhm  
 TCR_3K for 3kOhm  
-TCR_6K for 6kOhm  
-TCR_11K for 11kOhm  
+TCR_5K for 5kOhm  
+TCR_9K for 9kOhm  
+TCR_15K for 15kOhm  
 See [*Application Manual p. 48*](https://www.microcrystal.com/fileadmin/Media/Products/RTC/App.Manual/RV-3028-C7_App-Manual.pdf#page=48) for more information.
 
 <hr>

--- a/examples/Example3-Trickle_Charging/Example3-Trickle_Charging.ino
+++ b/examples/Example3-Trickle_Charging/Example3-Trickle_Charging.ino
@@ -34,10 +34,10 @@ void setup() {
   Serial.print("Config EEPROM 0x37 before: ");
   Serial.println(rtc.readConfigEEPROM_RAMmirror(0x37));
 
-  rtc.enableTrickleCharge(0);   //series resistor 3kOhm
-  //rtc.enableTrickleCharge(1); //series resistor 5kOhm
-  //rtc.enableTrickleCharge(2); //series resistor 9kOhm
-  //rtc.enableTrickleCharge(3); //series resistor 15kOhm
+  rtc.enableTrickleCharge(TCR_3K);   //series resistor 3kOhm
+  //rtc.enableTrickleCharge(TCR_5K); //series resistor 5kOhm
+  //rtc.enableTrickleCharge(TCR_9K); //series resistor 9kOhm
+  //rtc.enableTrickleCharge(TCR_15K); //series resistor 15kOhm
   //rtc.disableTrickleCharge(); //Trickle Charger disabled
 
   Serial.print("Config EEPROM 0x37 after: ");

--- a/examples/Example3-Trickle_Charging/Example3-Trickle_Charging.ino
+++ b/examples/Example3-Trickle_Charging/Example3-Trickle_Charging.ino
@@ -34,10 +34,10 @@ void setup() {
   Serial.print("Config EEPROM 0x37 before: ");
   Serial.println(rtc.readConfigEEPROM_RAMmirror(0x37));
 
-  rtc.enableTrickleCharge(0);   //series resistor 1kOhm
-  //rtc.enableTrickleCharge(1); //series resistor 3kOhm
-  //rtc.enableTrickleCharge(2); //series resistor 6kOhm
-  //rtc.enableTrickleCharge(3); //series resistor 11kOhm
+  rtc.enableTrickleCharge(0);   //series resistor 3kOhm
+  //rtc.enableTrickleCharge(1); //series resistor 5kOhm
+  //rtc.enableTrickleCharge(2); //series resistor 9kOhm
+  //rtc.enableTrickleCharge(3); //series resistor 15kOhm
   //rtc.disableTrickleCharge(); //Trickle Charger disabled
 
   Serial.print("Config EEPROM 0x37 after: ");

--- a/src/RV-3028-C7.cpp
+++ b/src/RV-3028-C7.cpp
@@ -599,11 +599,11 @@ void RV3028::clearPeriodicUpdateInterruptFlag()
 }
 
 /*********************************
-Enable the Trickle Charger and set the Trickle Charge series resistor (default is 11k)
-TCR_1K  =  1kOhm
+Enable the Trickle Charger and set the Trickle Charge series resistor (default is 15k)
 TCR_3K  =  3kOhm
-TCR_6K  =  6kOhm
-TCR_11K = 11kOhm
+TCR_5K  =  5kOhm
+TCR_9K  =  9kOhm
+TCR_15K = 15kOhm
 *********************************/
 void RV3028::enableTrickleCharge(uint8_t tcr)
 {

--- a/src/RV-3028-C7.h
+++ b/src/RV-3028-C7.h
@@ -156,10 +156,10 @@ Distributed as-is; no warranty is given.
 
 #define EEPROMBackup_BSM_CLEAR			0b11110011		//Backup Switchover Mode clear
 #define EEPROMBackup_TCR_CLEAR			0b11111100		//Trickle Charge Resistor clear
-#define	TCR_1K							0b00			//Trickle Charge Resistor 1kOhm
-#define	TCR_3K							0b01			//Trickle Charge Resistor 3kOhm
-#define	TCR_6K							0b10			//Trickle Charge Resistor 6kOhm
-#define	TCR_11K							0b11			//Trickle Charge Resistor 11kOhm
+#define	TCR_3K							0b00			//Trickle Charge Resistor 3kOhm
+#define	TCR_5K							0b01			//Trickle Charge Resistor 5kOhm
+#define	TCR_9K							0b10			//Trickle Charge Resistor 9kOhm
+#define	TCR_15K							0b11			//Trickle Charge Resistor 15kOhm
 
 
 // Clock output register (0x35)
@@ -259,7 +259,7 @@ public:
 	bool readPeriodicUpdateInterruptFlag();
 	void clearPeriodicUpdateInterruptFlag();
 
-	void enableTrickleCharge(uint8_t tcr = TCR_11K); //Trickle Charge Resistor default 11k
+	void enableTrickleCharge(uint8_t tcr = TCR_15K); //Trickle Charge Resistor default 15k
 	void disableTrickleCharge();
 	bool setBackupSwitchoverMode(uint8_t val);
 


### PR DESCRIPTION
Update trickle charge resistor values to match datasheet. 

This is a breaking change. If callers use previous enableTrickleCharge() values (TCR_1K, TCR_6K, TCR_11K) their code will fail to compile. 