### PR TITLE
Class Constructor Overwrites EEPROM

### DIFF
--- a/src/RV-3028-C7.cpp
+++ b/src/RV-3028-C7.cpp
@@ -68,7 +68,8 @@ RV3028::RV3028(void)
 {
 
 }
-
+// This call overwrites EEPROM settings. Caller should be able to construct class without 
+// overwriting EEPROM. Especially when they don't know the current EEPROM settings.
 bool RV3028::begin(TwoWire &wirePort, bool set_24Hour, bool disable_TrickleCharge, bool set_LevelSwitchingMode)
 {
 	//We require caller to begin their I2C port, with the speed of their choice

--- a/src/RV-3028-C7.h
+++ b/src/RV-3028-C7.h
@@ -202,7 +202,8 @@ class RV3028
 public:
 
 	RV3028(void);
-
+	// This call overwrites EEPROM settings. Caller should be able to construct class without 
+	// overwriting EEPROM. Especially when they don't know the current EEPROM settings.
 	bool begin(TwoWire &wirePort = Wire, bool set_24Hour = true, bool disable_TrickleCharge = true, bool set_LevelSwitchingMode = true);
 
 	bool setTime(uint8_t sec, uint8_t min, uint8_t hour, uint8_t weekday, uint8_t date, uint8_t month, uint16_t year);


### PR DESCRIPTION
Class constructor overwrites EEPROM settings. Caller should be able to construct class without overwriting EEPROM. Especially when caller doesn't know the current EEPROM settings.