### PR TITLE
Added disable_StatusReset to begin()

### DIFF
--- a/src/RV-3028-C7.cpp
+++ b/src/RV-3028-C7.cpp
@@ -69,7 +69,7 @@ RV3028::RV3028(void)
 
 }
 
-bool RV3028::begin(TwoWire &wirePort, bool set_24Hour, bool disable_TrickleCharge, bool set_LevelSwitchingMode)
+bool RV3028::begin(TwoWire &wirePort, bool set_24Hour, bool disable_TrickleCharge, bool set_LevelSwitchingMode, bool disable_StatusReset)
 {
 	//We require caller to begin their I2C port, with the speed of their choice
 	//external to the library
@@ -80,7 +80,7 @@ bool RV3028::begin(TwoWire &wirePort, bool set_24Hour, bool disable_TrickleCharg
 	if (set_24Hour) { set24Hour(); delay(1); }
 	if (disable_TrickleCharge) { disableTrickleCharge(); delay(1); }
 
-	return((set_LevelSwitchingMode ? setBackupSwitchoverMode(3) : true) && writeRegister(RV3028_STATUS, 0x00));
+	return((set_LevelSwitchingMode ? setBackupSwitchoverMode(3) : true) && (disable_StatusReset ? true : writeRegister(RV3028_STATUS, 0x00)));
 }
 
 bool RV3028::setTime(uint8_t sec, uint8_t min, uint8_t hour, uint8_t weekday, uint8_t date, uint8_t month, uint16_t year)

--- a/src/RV-3028-C7.h
+++ b/src/RV-3028-C7.h
@@ -203,7 +203,7 @@ public:
 
 	RV3028(void);
 
-	bool begin(TwoWire &wirePort = Wire, bool set_24Hour = true, bool disable_TrickleCharge = true, bool set_LevelSwitchingMode = true);
+	bool begin(TwoWire &wirePort = Wire, bool set_24Hour = true, bool disable_TrickleCharge = true, bool set_LevelSwitchingMode = true, bool disable_StatusReset = false);
 
 	bool setTime(uint8_t sec, uint8_t min, uint8_t hour, uint8_t weekday, uint8_t date, uint8_t month, uint16_t year);
 	bool setTime(uint8_t * time, uint8_t len);


### PR DESCRIPTION
Added disable_StatusReset to begin() function to retain all status bits during 2-wire initialization.

This is used to not clear the interrupt flags when initializing i2c communication.
Useful in scenarios where the RTC powers the μC that is also speaking to the RTC after waking up through an interrupt and the μC relies on the low interrupt signal and what triggered it.