### PR TITLE
Add User EEPROM 

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,13 @@ Set Clockout Frequency _freq_ as follows:
 See [*Application Manual p. 48*](https://www.microcrystal.com/fileadmin/Media/Products/RTC/App.Manual/RV-3028-C7_App-Manual.pdf#page=48) for more information.
 'enableInterruptControlledClockout' generally enables the Interrupt Controlled Clockout (required for triggering Clockout at Alarm, PeriodicUpdate and CountdownTimer Interrupts).
 
+<hr>
+
+### User EEPROM
+
+###### `writeUserEEPROM(uint8_t eepromaddr, uint8_t val)`
+###### `readUserEEPROM(uint8_t eepromaddr)`
+
 
 License Information
 -------------------

--- a/src/RV-3028-C7.h
+++ b/src/RV-3028-C7.h
@@ -283,6 +283,8 @@ public:
 
 	bool writeConfigEEPROM_RAMmirror(uint8_t eepromaddr, uint8_t val);
 	uint8_t readConfigEEPROM_RAMmirror(uint8_t eepromaddr);
+	bool writeUserEEPROM(uint8_t eepromaddr, uint8_t val);
+	uint8_t readUserEEPROM(uint8_t eepromaddr);
 	bool waitforEEPROM();
 	void reset();
 


### PR DESCRIPTION
The RV-3028-C7 offers 43bytes of user EEPROM from 0x00 to 0x2A. I've added read and write functions to access this.